### PR TITLE
Fix: change NSFastEnumeration IMP to support tuple nil element

### DIFF
--- a/Example/Tests/ZTupleTests.m
+++ b/Example/Tests/ZTupleTests.m
@@ -171,16 +171,16 @@ describe(@"tuple tests", ^{
     
     context(@"fast enumeration", ^{
         it(@"can use for in to access tuple", ^{
-            ZTuple20 *tuple = ZTuple(@1, @2, @3, @4, @5, @6, @7, @8, @9, @10,
-                                     @11, @12, @13, @14, @15, @16, @17, @18, @19, @20);
+            ZTuple20 *tuple = ZTuple(nil, @2, @3, @4, nil, nil, @7, @8, @9, @10,
+                                     @11, @12, @13, @14, @15, @16, @17, @18, nil, @20);
             
             NSMutableArray *array = [NSMutableArray array];
             
             for(NSNumber *number in tuple) {
                 [array addObject:number];
             }
-            expect(array).to.equal(@[@1, @2, @3, @4, @5, @6, @7, @8, @9, @10,
-                                     @11, @12, @13, @14, @15, @16, @17, @18, @19, @20]);
+            expect(array).to.equal(@[@2, @3, @4, @7, @8, @9, @10,
+                                     @11, @12, @13, @14, @15, @16, @17, @18, @20]);
         });
         
         it(@"will raise error if modify any item when enumeration", ^{

--- a/Example/Tests/ZTupleTests.m
+++ b/Example/Tests/ZTupleTests.m
@@ -171,16 +171,16 @@ describe(@"tuple tests", ^{
     
     context(@"fast enumeration", ^{
         it(@"can use for in to access tuple", ^{
-            ZTuple20 *tuple = ZTuple(nil, @2, @3, @4, nil, nil, @7, @8, @9, @10,
-                                     @11, @12, @13, @14, @15, @16, @17, @18, nil, @20);
+            ZTuple20 *tuple = ZTuple(@1, @2, @3, @4, @5, @6, @7, @8, @9, @10,
+                                     @11, @12, @13, @14, @15, @16, @17, @18, @19, @20);
             
             NSMutableArray *array = [NSMutableArray array];
             
             for(NSNumber *number in tuple) {
                 [array addObject:number];
             }
-            expect(array).to.equal(@[@2, @3, @4, @7, @8, @9, @10,
-                                     @11, @12, @13, @14, @15, @16, @17, @18, @20]);
+            expect(array).to.equal(@[@1, @2, @3, @4, @5, @6, @7, @8, @9, @10,
+                                     @11, @12, @13, @14, @15, @16, @17, @18, @19, @20]);
         });
         
         it(@"will raise error if modify any item when enumeration", ^{
@@ -205,6 +205,22 @@ describe(@"tuple tests", ^{
             
             objc_setEnumerationMutationHandler(NULL);
         });
+    });
+    
+    context(@"fast enumeration", ^{
+        it(@"can use for in to access tuple and auto ignore nil value", ^{
+            ZTuple20 *tuple = ZTuple(nil, @2, @3, @4, nil, nil, @7, @8, @9, @10,
+                                     @11, @12, @13, @14, @15, @16, @17, @18, nil, @20);
+            
+            NSMutableArray *array = [NSMutableArray array];
+            
+            for(NSNumber *number in tuple) {
+                [array addObject:number];
+            }
+            expect(array).to.equal(@[@2, @3, @4, @7, @8, @9, @10,
+                                     @11, @12, @13, @14, @15, @16, @17, @18, @20]);
+        });
+        
     });
     
     context(@"copy", ^{


### PR DESCRIPTION
由于`Tuple`可以存储`nil`，所以在进行`for....in`迭代时，若存在元素为`nil`值，添加到不能存储`nil`的集合中，导致崩溃。